### PR TITLE
Address missing token message

### DIFF
--- a/hugie/endpoint.py
+++ b/hugie/endpoint.py
@@ -17,6 +17,15 @@ headers = {
 API_ERROR_MESSAGE = "An error occured while making the API call"
 
 
+class TokenNotSet(Exception):
+    def __str__(self):
+        return "You need to define a token using the environment variable HUGGINGFACE_READ_TOKEN"
+
+
+if not settings.token:
+    raise TokenNotSet
+
+
 @app.command("ls")
 @app.command("list")
 def list(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import os
+
+os.environ["HUGGINGFACE_READ_TOKEN"] = "token"


### PR DESCRIPTION
# Description

Not sure thats the best solution. I experimented with both using `BaseSettings` and a `validation` in `BaseModel` see https://pydantic-docs.helpmanual.io/usage/validators/. In both cases the error handling is managed by typer so the messaging is not as clean.

This is the current message
```
Traceback (most recent call last):
  File "/workspaces/hugie/.venv/bin/hugie", line 5, in <module>
    from hugie.cli import app
  File "/workspaces/hugie/hugie/cli.py", line 3, in <module>
    from hugie.endpoint import app as endpoint_app
  File "/workspaces/hugie/hugie/endpoint.py", line 9, in <module>
    settings = Settings()
  File "pydantic/env_settings.py", line 39, in pydantic.env_settings.BaseSettings.__init__
  File "pydantic/main.py", line 342, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for Settings
huggingface_read_token
  field required (type=value_error.missing)
```

Maybe we accept the token as it was and check in `endpoint.py` and throw there a typer message?

Fixes #35 

# Checklist

- [x] Tests added
- [x] Relevant issue mentioned
- [ ] Documentation updated
