### PR TITLE
Don't set top_k when running `hugie endpoint test` (fixes #48)

### DIFF
--- a/hugie/endpoint.py
+++ b/hugie/endpoint.py
@@ -291,7 +291,7 @@ def test(
     if input_file:
         data = load_json(input_file)
     else:
-        data = {"inputs": inputs, "parameters": {"top_k": 10}}
+        data = {"inputs": inputs}
 
     # Send a call to the endpoint
     try:


### PR DESCRIPTION
# Description

Fixes #48 by removing the `top_k` parameter from `hugie endpoint test`.


# Checklist

- [x] Tests added
- [x] Relevant issue mentioned
- [x] Documentation updated
