### PR TITLE
Minor tweaks to endpoint sub-command

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: docs
-on: pull_request
+on:
+  push:
+    branches:
+      - main
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Adds `ls` alias to `list` command #50
+- Adds `-f` shortcut to `--force` command #50
+
+### Changed
+- Only create docs on merge to main #50
+
+### Removed
+- Removes `--no-force` option to `delete` command #50
+
 ## [0.2.0]
 
 ✨ Renamed to Hugie 🐻

--- a/hugie/endpoint.py
+++ b/hugie/endpoint.py
@@ -17,7 +17,8 @@ headers = {
 API_ERROR_MESSAGE = "An error occured while making the API call"
 
 
-@app.command()
+@app.command("ls")
+@app.command("list")
 def list(
     json: Optional[bool] = typer.Option(
         None, "--json", help="Prints the full output in JSON."
@@ -149,7 +150,7 @@ def update(
 def delete(
     name: str = typer.Argument(..., help="Endpoint name"),
     force: bool = typer.Option(
-        False, help="Force deletion without asking user confirmation"
+        False, "--force", "-f", help="Force deletion without asking user confirmation"
     ),
 ):
     """


### PR DESCRIPTION
# Description

### Added
- Adds `ls` alias to `list` command
- Adds `-f` shortcut to `--force` command

### Changed
- Only create docs on merge to main

### Removed
- Removes `--no-force` option to `delete` command

# Checklist

- [ ] Tests added
- [ ] Relevant issue mentioned
- [ ] Documentation updated
