### PR TITLE
Add --name-suffix option to `endpoint create` (fixes #56)

### DIFF
--- a/hugie/endpoint.py
+++ b/hugie/endpoint.py
@@ -96,6 +96,14 @@ def create(
     data = InferenceEndpointConfig.from_json(data).dict()
 
     if name_suffix:
+        if len(name_suffix) > 5:
+            name_suffix = name_suffix[:5]
+            typer.secho("The name suffix should be 5 characters or fewer")
+            typer.secho(
+                "Truncating suffix to {name_suffix}",
+                fg=typer.colors.RED,
+            )
+
         data["name"] = f"{data['name']}-{name_suffix}"
         typer.secho(f"Endpoint name set to {data['name']}", fg=typer.colors.YELLOW)
 


### PR DESCRIPTION
# Description

Fixes #56 by adding an option to add a user defined suffix to endpoint names.

Positively, this means:
* You can deploy multiple endpoints based off the same config
* You do not need to destroy an existing endpoint before launching a new one from the same config

Negatively:
* The endpoint may become out of sync with the config if a suffix is added. 

Because endpoint names are limited, the suffix will be truncated to 5 characters, i.e. enough for a `1.0.0` or the first 5 characters of a git commit hash.

# Checklist

- [ ] Tests added
- [X] Relevant issue mentioned
- [ ] Documentation updated
