### PR TITLE
Allow a URL for a config JSON to be passed instead to create and update

### DIFF
--- a/hugie/config.py
+++ b/hugie/config.py
@@ -8,7 +8,7 @@ app = typer.Typer()
 
 @app.command()
 def modify(
-    path: str,
+    path: str = typer.Argument(..., help="File path or url of config file"),
     accountId: str = typer.Option(
         None, help="ID of the account (for private endpoints)"
     ),

--- a/hugie/endpoint.py
+++ b/hugie/endpoint.py
@@ -87,8 +87,12 @@ def create(
     Args:
         data (str): Path to JSON data to create the endpoint
     """
+    # Check whether data is a path or url
 
-    data = InferenceEndpointConfig.from_json(data).dict()
+    if data.startswith("http"):
+        data = InferenceEndpointConfig.from_url(data).dict()
+    else:
+        data = InferenceEndpointConfig.from_json(data).dict()
 
     try:
         response = requests.post(settings.endpoint_url, headers=headers, json=data)
@@ -126,7 +130,10 @@ def update(
     """
     Update an endpoint
     """
-    data = dict(InferenceEndpointConfig.from_json(data))
+    if data.startswith("http"):
+        data = InferenceEndpointConfig.from_url(data).dict()
+    else:
+        data = InferenceEndpointConfig.from_json(data).dict()
 
     try:
         response = requests.put(

--- a/hugie/models.py
+++ b/hugie/models.py
@@ -1,3 +1,4 @@
+import requests
 from pydantic import BaseModel, BaseSettings
 
 from hugie.utils import load_json
@@ -9,7 +10,6 @@ class ScalingModel(BaseModel):
 
 
 class ComputeModel(BaseModel):
-
     accelerator: str = None
     instanceSize: str = None
     instanceType: str = None
@@ -17,7 +17,6 @@ class ComputeModel(BaseModel):
 
 
 class ModelModel(BaseModel):
-
     framework: str = None
     image: dict = {"huggingface": {}}
     repository: str = None
@@ -43,12 +42,22 @@ class InferenceEndpointConfig(BaseSettings):
     provider: ProviderModel = ProviderModel()
 
     @classmethod
+    def from_url(self, url: str):
+        """
+        Load a config from a url
+        """
+        config = requests.get(url).json()
+        return self.create_config(self, config)
+
+    @classmethod
     def from_json(self, path: str):
         """
         Load a config from a JSON file.
         """
         config = load_json(path)
+        return self.create_config(self, config)
 
+    def create_config(self, config: dict):
         model = ModelModel(
             framework=config["model"]["framework"],
             image=config["model"]["image"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hugie
-version = 0.3.0
+version = 0.4.0
 author = Matthew Upson, Nick Sorros
 author_email = hi@mantisnlp.com
 description = Package for managing huggingface inference endpoints


### PR DESCRIPTION
# Description

Writing a blog post on hugie, and it occured to me that this might be a nice feature. If nothing else, it makes it very easy to get started quickly.

# Checklist

- [ ] Tests added
- [ ] Relevant issue mentioned
- [ ] Documentation updated
