### PR TITLE
Add `hugie ui` command (Fixes #30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2]
+
 ### Added
 - Add endpoint config subcommand #47 (resolves #41)
 - Adds `ls` alias to `list` command #50
 - Adds `-f` shortcut to `--force` command #50
+- Adds `poetry` for dependency management #69
+- Adds `ui` command to open Hugging Face Inference Endpoint website in browser #70
 
 ### Changed
 - Only create docs on merge to main #50
 
 ### Removed
 - Removes `--no-force` option to `delete` command #50
+
+### Fixed
+- Breaking changes introduced by pydantic 2.0.0 #68
+- Fix data bug in `update` function #63
 
 ## [0.2.0]
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Options:
   --help                          Show this message and exit.
 
 Commands:
+  Commands:
   config
   endpoint
-  version   Show version.
+  ui        Open the Hugging Face Endpoints UI in a browser
+  version   Print hugie version
 ```
 
 # Endpoint

--- a/hugie/__main__.py
+++ b/hugie/__main__.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+import webbrowser
 
 import typer
 
@@ -10,8 +11,20 @@ app = typer.Typer()
 
 @app.command()
 def version():
-    """Show version."""
+    """Print hugie version"""
     typer.echo(importlib.metadata.version("hugie"))
+    typer.Exit(0)
+
+
+@app.command("ui")
+def open_ui():
+    """
+    Open the Hugging Face Endpoints UI in a browser
+    """
+    url = "https://ui.endpoints.huggingface.co/"
+    typed_url = typer.style(url, fg=typer.colors.BLUE, bold=True)
+    typer.echo(f"Opening {typed_url} in your browser...")
+    webbrowser.open(url)
     typer.Exit(0)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hugie"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI for managing Hugging Face Inference Endpoints"
 authors = ["Matthew Upson <matt@mantisnlp.com>",
             "Nick Sorros <nick@mantisnlp.com>"]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from hugie.__main__ import app
 from typer.testing import CliRunner
 
@@ -5,8 +7,9 @@ runner = CliRunner()
 
 
 def test_ui_command(monkeypatch):
-    def mock_open(url):
-        return "Opening https://ui.endpoints.huggingface.co/ in your browser..."
+    mock_open = Mock(
+        return_value="Opening https://ui.endpoints.huggingface.co/ in your browser..."
+    )
 
     # Use monkeypatch to replace the ui function with the mock function
     monkeypatch.setattr("webbrowser.open", mock_open)
@@ -19,3 +22,6 @@ def test_ui_command(monkeypatch):
         "Opening https://ui.endpoints.huggingface.co/ in your browser..."
         in result.output
     )
+
+    # Check that the mock was called
+    mock_open.assert_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,21 @@
+from hugie.__main__ import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_ui_command(monkeypatch):
+    def mock_open(url):
+        return "Opening https://ui.endpoints.huggingface.co/ in your browser..."
+
+    # Use monkeypatch to replace the ui function with the mock function
+    monkeypatch.setattr("webbrowser.open", mock_open)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["ui"])
+
+    assert result.exit_code == 0
+    assert (
+        "Opening https://ui.endpoints.huggingface.co/ in your browser..."
+        in result.output
+    )


### PR DESCRIPTION
# Description

Resolves #'30 by adding the  `hugie ui` command which opens the Hugging Face Inference Endpoints dashboard in a browser.

This may be the killer function for this tool :grimacing: 

# Checklist

- [x] Tests added
- [x] Relevant issue mentioned
- [X] Documentation updated
