### PR TITLE
Simplify Requests error handling (Fixes #71)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run tests
-on: pull_request
+on:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   Run-tests:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0..0.3.2] 2023-07-27
+
 ### Added
 - Add endpoint config subcommand #47 (resolves #41)
 - Adds `ls` alias to `list` command #50
 - Adds `-f` shortcut to `--force` command #50
+- Adds `hugie ui` command #70
 
 ### Changed
 - Only create docs on merge to main #50
+- Switch to poetry for dependency management #69
+- Don't set `top_k` when running `hugie endpoint test` #49
 
 ### Removed
 - Removes `--no-force` option to `delete` command #50
+
+### Fixed
+- Fixes error handling flows #72
+- Fixes breaking changes introduced by pydantic 2.0 #68
+- Fix data bug in update function #63
+- Address missing token message #46
+- Handle 40x responses in create #45
+- Update now handles 40x codes #44
+- Removve --no-json from cli #43
+
 
 ## [0.2.0]
 

--- a/hugie/endpoint.py
+++ b/hugie/endpoint.py
@@ -3,6 +3,7 @@ from typing import Optional
 import requests
 import typer
 
+from hugie.exceptions import TokenNotSetError, handle_requests_error
 from hugie.models import InferenceEndpointConfig
 from hugie.settings import Settings
 from hugie.utils import format_table, load_json
@@ -18,13 +19,8 @@ headers = {
 API_ERROR_MESSAGE = "An error occured while making the API call"
 
 
-class TokenNotSet(Exception):
-    def __str__(self):
-        return "You need to define a token using the environment variable HUGGINGFACE_READ_TOKEN"
-
-
 if not settings.token:
-    raise TokenNotSet
+    raise TokenNotSetError
 
 
 @app.command("ls")
@@ -89,30 +85,39 @@ def create(
     """
 
     data = InferenceEndpointConfig.from_json(data).model_dump()
+    name = data["name"]
+    vendor = data["provider"]["vendor"]
+    repository = data["model"]["repository"]
 
     try:
+        # Try to create the endpoint
+
         response = requests.post(settings.endpoint_url, headers=headers, json=data)
         response.raise_for_status()
-    except requests.exceptions.HTTPError as e:
-        typer.secho("Error creating endpoint", fg=typer.colors.RED)
-        raise SystemExit(e)
-    except requests.exceptions.RequestException as e:
-        typer.secho(API_ERROR_MESSAGE, fg=typer.colors.RED)
+
+    except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as e:
+
+        handle_requests_error(e)
+
+    except Exception as e:
+
+        # Catch all other exceptions
+
+        typer.secho("An unexpected error occured", fg=typer.colors.RED)
         raise SystemExit(e)
 
-    if response.status_code == 400:
-        typer.secho(f"Malformed data in {data}", fg=typer.colors.YELLOW)
-    elif response.status_code == 401:
-        typer.secho("Invalid token", fg=typer.colors.YELLOW)
-    elif response.status_code == 409:
-        typer.secho(f"Endpoint {name} already exists", fg=typer.colors.YELLOW)
     else:
+
+        # If the command succeeds print this output and exit with code 0
+
         typer.secho(
-            f"Endpoint {data['name']} created successfully on {data['provider']['vendor']} using {data['model']['repository']}",
+            f"Endpoint {name} created successfully on {vendor} using {repository}",
             fg=typer.colors.GREEN,
         )
-    if json:
-        typer.echo(response.json())
+
+        if json:
+            typer.echo(response.json())
+        typer.Exit(0)
 
 
 @app.command()
@@ -132,29 +137,26 @@ def update(
         response = requests.put(
             f"{settings.endpoint_url}/{name}", headers=headers, json=data
         )
-    except requests.exceptions.HTTPError as e:
-        if response.json().get("error"):
-            typer.secho(
-                f"Error updating endpoint: {response.json()['error']}",
-                fg=typer.colors.RED,
-            )
-        else:
-            typer.secho("Error updating endpoint", fg=typer.colors.RED)
-        raise SystemExit(e)
-    except requests.exceptions.RequestException as e:
-        typer.secho(API_ERROR_MESSAGE, fg=typer.colors.RED)
+        response.raise_for_status()
+
+    except (requests.exceptions.HTTPError, requests.exceptions.RequestException) as e:
+
+        handle_requests_error(e)
+
+    except Exception as e:
+
+        # Catch all other exceptions
+
+        typer.secho("An unexpected error occured", fg=typer.colors.RED)
         raise SystemExit(e)
 
-    if response.status_code == 400:
-        typer.secho("Malformed data in {data}", fg=typer.colors.YELLOW)
-    elif response.status_code == 401:
-        typer.secho("Token provided not valid", fg=typer.colors.YELLOW)
-    elif response.status_code == 404:
-        typer.secho("Endpoint {name} not found", fg=typer.colors.YELLOW)
     else:
         typer.secho("Endpoint updated successfully", fg=typer.colors.GREEN)
-    if json:
-        typer.echo(response.json())
+
+        if json:
+            typer.echo(response.json())
+
+        typer.Exit(0)
 
 
 @app.command()

--- a/hugie/exceptions.py
+++ b/hugie/exceptions.py
@@ -1,0 +1,59 @@
+import requests
+import typer
+
+
+class TokenNotSetError(Exception):
+    def __str__(self):
+        return "You need to define a token using the environment variable HUGGINGFACE_READ_TOKEN"
+
+
+def handle_requests_error(exception, data):
+    """
+    Generic HTTP error handling function. Takes an HTTPError or RequestException
+    instance as input and handles the error by printing an appropriate message
+    and exiting the program.
+
+    Args:
+        exception (requests.exceptions.HTTPError): HTTPError or RequestException instance
+        data (dict): Hugging Face Inference Endpoint configuration
+    """
+    # Print a general API error message
+    typer.secho("An error occurred with the API request.", fg=typer.colors.RED)
+
+    # If the exception is an HTTPError, provide more specific error messages
+    # based on the status code
+
+    if isinstance(exception, requests.exceptions.HTTPError):
+        status_code = exception.response.status_code
+
+        if status_code == 400:
+            typer.secho(f"Malformed data in request: {data}", fg=typer.colors.YELLOW)
+        elif status_code == 401:
+            typer.secho("Invalid API token.", fg=typer.colors.YELLOW)
+        elif status_code == 404:
+            typer.secho("Endpoint with this name not found", fg=typer.colors.YELLOW)
+        elif status_code == 409:
+            typer.secho(
+                "Conflict: An endpoint with this name already exists.",
+                fg=typer.colors.YELLOW,
+            )
+        else:
+            typer.secho("An HTTP error occurred.", fg=typer.colors.RED)
+
+    elif isinstance(exception, requests.exceptions.ConnectionError):
+        typer.secho("A network problem occurred.", fg=typer.colors.RED)
+    elif isinstance(exception, requests.exceptions.Timeout):
+        typer.secho("The request timed out.", fg=typer.colors.RED)
+    elif isinstance(exception, requests.exceptions.TooManyRedirects):
+        typer.secho(
+            "The request exceeded the configured number of maximum redirections.",
+            fg=typer.colors.RED,
+        )
+    elif isinstance(exception, requests.exceptions.RequestException):
+        typer.secho(
+            "An error occurred while handling the request.", fg=typer.colors.RED
+        )
+
+    # Exit the program with an error code
+
+    raise SystemExit(exception)

--- a/poetry.lock
+++ b/poetry.lock
@@ -702,6 +702,23 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.11.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "pytest-mock-3.11.1.tar.gz", hash = "sha256:7f6b125602ac6d743e523ae0bfa71e1a697a2f5534064528c6ff84c2f7c2fc7f"},
+    {file = "pytest_mock-3.11.1-py3-none-any.whl", hash = "sha256:21c279fff83d70763b05f8874cc9cfb3fcacd6d354247a976f9529d19f9acf39"},
+]
+
+[package.dependencies]
+pytest = ">=5.0"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1128,4 +1145,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d79f764ecbbee92f8c2037f1dc8cd49fc780f50d979c2f36e11e6f9c43a2bdfd"
+content-hash = "ab4fc5369352a20b52f254a4132ce27ed3b6a78e4a1ad0f5c988f69a84cf7bf4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ requests = "^2.31.0"
 pydantic = "^2.0.3"
 srsly = "^2.4.7"
 pydantic-settings = "^2.0.2"
+pytest-mock = "^3.11.1"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.3.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hugie"
-version = "0.3.1"
+version = "0.3.2"
 description = "CLI for managing Hugging Face Inference Endpoints"
 authors = ["Matthew Upson <matt@mantisnlp.com>",
             "Nick Sorros <nick@mantisnlp.com>"]

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -75,6 +75,9 @@ def test_update(monkeypatch, data_path):
         def json():
             pass
 
+        def raise_for_status():
+            pass
+
         status_code = 200
 
     monkeypatch.setattr("requests.put", lambda url, headers, json: MockUpdateResponse)

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,93 @@
+import pytest
+from hugie.exceptions import TokenNotSetError, handle_requests_error
+from requests.exceptions import (
+    ConnectionError,
+    HTTPError,
+    RequestException,
+    Timeout,
+    TooManyRedirects,
+)
+
+
+def test_TokenNotSetError():
+    exception = TokenNotSetError()
+    assert (
+        str(exception)
+        == "You need to define a token using the environment variable HUGGINGFACE_READ_TOKEN"
+    )
+
+
+def test_handle_requests_error_HTTPError_400(mocker):
+    mock_response = mocker.Mock(status_code=400)
+    exception = HTTPError(response=mock_response)
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {"data": "test"})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_HTTPError_401(mocker):
+    mock_response = mocker.Mock(status_code=401)
+    exception = HTTPError(response=mock_response)
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {"data": "test"})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_HTTPError_409(mocker):
+    mock_response = mocker.Mock(status_code=409)
+    exception = HTTPError(response=mock_response)
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {"data": "test"})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_HTTPError_other(mocker):
+    mock_response = mocker.Mock(status_code=500)
+    exception = HTTPError(response=mock_response)
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {"data": "test"})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_ConnectionError(monkeypatch):
+    exception = ConnectionError()
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_Timeout(monkeypatch):
+    exception = Timeout()
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_TooManyRedirects(monkeypatch):
+    exception = TooManyRedirects()
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {})
+
+    assert str(e.value) == str(exception)
+
+
+def test_handle_requests_error_RequestException(monkeypatch):
+    exception = RequestException()
+
+    with pytest.raises(SystemExit) as e:
+        handle_requests_error(exception, {})
+
+    assert str(e.value) == str(exception)


### PR DESCRIPTION
# Description

* Resolves #71 which meant that all the error handling logic for different HTTP errors across all commands (not just `create` as described in #64 and resolved in #65) would never get triggered.
* Also creates an `exceptions` module and abstracts the error handling logic for Requests errors into a handler function.
* Adds `test_exceptions` module to test functionality of the error handler.
* Note that this will supersede https://github.com/MantisAI/hugie/pull/65

# Checklist

- [X] Tests added
- [X] Relevant issue mentioned
- [ ] Documentation updated
